### PR TITLE
Pagination

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,0 +1,8 @@
+## Task Priorities
+
+1. Fix vulnerabilities - Ensure we're not shipping critical vulnerabilities. It's always easier when you upgrade early and often.
+2. Pagination (start types) - Reduce risk of crushing user experience with potentially large payloads.
+3. Search functionality - Fix broken UX. Minimum usability.
+4. Serial > UUID - Security enhancement now that users are unblocked.
+5. Sorting - Make it even more usable.
+6. Styling - Make the app "feel" more real (building trust) and even easier to use.

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,25 @@
+import { count } from "drizzle-orm";
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
 
-export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
+export async function GET(request: Request): Promise<Response> {
+  // set up query params
+  const { searchParams } = new URL(request.url);
+  const page: number = parseInt(searchParams.get("page") ?? "1");
+  const limit: number = parseInt(searchParams.get("limit") ?? "10");
 
-  const data = advocateData;
 
-  return Response.json({ data });
+  // set up page metadata
+  let pageData = db.select({count: count()}).from(advocates);
+  const totalCount = (await pageData.execute())[0].count;
+  const totalPages = Math.ceil(totalCount / limit);
+  const hasNextPage = page < totalPages;
+  const hasPreviousPage = page > 1;
+
+  let offset = (page - 1) * limit;
+  let data = db.select().from(advocates);
+  data = data.offset(offset).limit(limit);
+
+  const resp = await data.execute();
+  return Response.json({ data: resp, page, limit, totalCount, totalPages, hasNextPage, hasPreviousPage });
 }

--- a/src/app/components/pagination.tsx
+++ b/src/app/components/pagination.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+interface PaginationProps {
+  page: number;
+  setNext: () => void;
+  setPrevious: () => void;
+  setPer: (per: number) => void;
+  perPage: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+};
+
+export default function Pagination ({
+  page,
+  setNext,
+  setPrevious,
+  setPer,
+  perPage,
+  totalPages,
+  hasNextPage,
+  hasPreviousPage,
+}: PaginationProps) {
+  const buttonStyle = "text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2"
+  return (
+  <div className="mt-4">
+    <span className="mr-2">Per Page</span>
+    <select onChange={(e) => setPer(parseInt(e.target.value))} value={perPage} className="border border-gray-300 rounded-lg p-2 mr-2">
+      <option value="10">10</option>
+      <option value="20">20</option>
+      <option value="50">50</option>
+      <option value="100">100</option>
+    </select>
+    <button onClick={setPrevious} disabled={!hasPreviousPage} className={buttonStyle}>{"<<"}</button>
+    <span className="mr-2 ml-2">{page} of {totalPages}</span>
+    <button onClick={setNext} disabled={!hasNextPage} className={buttonStyle}>{">>"}</button>
+  </div>
+);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,69 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Pagination from "./components/pagination";
+import { IAdvocate, IAdvocatesResponse } from "@/types";
 
 export default function Home() {
-  const [advocates, setAdvocates] = useState([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState([]);
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
+  const [advocates, setAdvocates] = useState<IAdvocate[]>([]);
+  const [filteredAdvocates, setFilteredAdvocates] = useState<IAdvocate[]>([]);
+
+
+  // Get initial values from URL params or defaults
+  const page = parseInt(searchParams.get("page") || "1");
+  const limit = parseInt(searchParams.get("limit") || "10");
+
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalCount, setTotalCount] = useState(0);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const [hasPreviousPage, setHasPreviousPage] = useState(false);
+
+  // Update URL parameters
+  const updateURL = (newParams: Record<string, string | number>) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    Object.entries(newParams).forEach(([key, value]) => {
+      if (value !== null && value !== undefined && value !== "") {
+        params.set(key, value.toString());
+      } else {
+        params.delete(key);
+      }
+    });
+
+    router.push(`/?${params.toString()}`, { scroll: false });
+  };
   useEffect(() => {
-    console.log("fetching advocates...");
-    fetch("/api/advocates").then((response) => {
-      response.json().then((jsonResponse) => {
+    fetchAdvocates();
+  }, [page, limit]);
+  
+  const fetchAdvocates = () => {
+    const urlParams = new URLSearchParams({
+      page: page.toString(),
+      limit: limit.toString(),
+    });
+
+    fetch(`/api/advocates?${urlParams.toString()}`).then((response: Response) => {
+      response.json().then((jsonResponse: IAdvocatesResponse) => {
         setAdvocates(jsonResponse.data);
-        setFilteredAdvocates(jsonResponse.data);
+        setTotalCount(jsonResponse.totalCount);
+        setTotalPages(jsonResponse.totalPages);
+        setHasNextPage(jsonResponse.hasNextPage);
+        setHasPreviousPage(jsonResponse.hasPreviousPage);
       });
     });
-  }, []);
+  };
+
+  const setPage = (newPage: number) => {
+    updateURL({ page: newPage });
+  };
+
+  const setLimit = (newLimit: number) => {
+    updateURL({ limit: newLimit });
+  };
 
   const onChange = (e) => {
     const searchTerm = e.target.value;
@@ -53,30 +102,42 @@ export default function Home() {
         </p>
         <input style={{ border: "1px solid black" }} onChange={onChange} />
         <button onClick={onClick}>Reset Search</button>
+        <Pagination 
+          setNext={() => setPage(page + 1)} 
+          setPrevious={() => setPage(page - 1)} 
+          page={page} 
+          setPer={setLimit} 
+          perPage={limit} 
+          totalPages={totalPages} 
+          hasNextPage={hasNextPage} 
+          hasPreviousPage={hasPreviousPage}
+        />
       </div>
       <br />
       <br />
       <table>
         <thead>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>City</th>
-          <th>Degree</th>
-          <th>Specialties</th>
-          <th>Years of Experience</th>
-          <th>Phone Number</th>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>City</th>
+            <th>Degree</th>
+            <th>Specialties</th>
+            <th>Years of Experience</th>
+            <th>Phone Number</th>
+          </tr>
         </thead>
         <tbody>
-          {filteredAdvocates.map((advocate) => {
+          {advocates.map((advocate: IAdvocate) => {
             return (
-              <tr>
+              <tr key={`advocate-${advocate.id}`}>
                 <td>{advocate.firstName}</td>
                 <td>{advocate.lastName}</td>
                 <td>{advocate.city}</td>
                 <td>{advocate.degree}</td>
                 <td>
                   {advocate.specialties.map((s) => (
-                    <div>{s}</div>
+                    <div key={`${advocate.id}-${s}`}>{s}</div>
                   ))}
                 </td>
                 <td>{advocate.yearsOfExperience}</td>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,21 @@
+export interface IAdvocate {
+  id: string;
+  firstName: string;
+  lastName: string;
+  city: string;
+  degree: 'MD' | 'PhD' | 'MSW'; // Based on seed data
+  specialties: string[];
+  yearsOfExperience: number;
+  phoneNumber: string;
+  createdAt?: Date;
+}
+
+export interface IAdvocatesResponse {
+  data: IAdvocate[];
+  page: number;
+  limit: number;
+  totalCount: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}


### PR DESCRIPTION
- Adds backend pagination with augmented API response (backward-compatible, see new type definitions below).
- Add frontend functionality to use pagination, including `Pagination` component.
- Puts pagination parameters in the query string to preserve experience between refreshes and make URLs save-able/share-able.

**Why?**
When we`GET` listing endpoints with indeterminate responses, we need to limit the response to a known number of records.  This reduces the response from the database using `limit` and `offset` so that the response payload is a [hopefully] reasonable size. This gives the user of the endpoint a quicker response and reduces load on underlying infrastructure and risk of adverse effects on other users.

**New Types**

```
export interface IAdvocate {
  id: string;
  firstName: string;
  lastName: string;
  city: string;
  degree: 'MD' | 'PhD' | 'MSW'; // Based on seed data
  specialties: string[];
  yearsOfExperience: number;
  phoneNumber: string;
  createdAt?: Date;
}

export interface IAdvocatesResponse {
  data: IAdvocate[];
  page: number;
  limit: number;
  totalCount: number;
  totalPages: number;
  hasNextPage: boolean;
  hasPreviousPage: boolean;
}
```

**Note**
The pagination metadata does add an extra database query. This isn't awesome, but we can evaluate the performance hit and make a decision to keep it or take a different approach with cursor-based pagination or leaning on caching.
   