### PR TITLE
Search

### DIFF
--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,4 +1,4 @@
-import { count } from "drizzle-orm";
+import { count, ilike, or, sql } from "drizzle-orm";
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
 
@@ -7,17 +7,37 @@ export async function GET(request: Request): Promise<Response> {
   const { searchParams } = new URL(request.url);
   const page: number = parseInt(searchParams.get("page") ?? "1");
   const limit: number = parseInt(searchParams.get("limit") ?? "10");
+  const search: string = searchParams.get("search") ?? "";
 
+  // set up data query
+  let data = db.select().from(advocates);
 
-  // set up page metadata
+  // set up page metadata query
   let pageData = db.select({count: count()}).from(advocates);
+
+  // add search conditions if search term is provided
+  if (search.trim()) {
+    const searchPattern = `%${search.trim()}%`;
+
+    const searchConditions = or(
+      ilike(advocates.firstName, `%${searchPattern}%`),
+      ilike(advocates.lastName, `%${searchPattern}%`),
+      ilike(advocates.city, `%${searchPattern}%`),
+      ilike(advocates.degree, `%${searchPattern}%`),
+      sql`${advocates.specialties}::text ILIKE ${'%' + searchPattern + '%'}`,
+    );
+    data = data.where(searchConditions);
+    pageData = pageData.where(searchConditions);
+  }
+
+
+  // gather page metadata
   const totalCount = (await pageData.execute())[0].count;
   const totalPages = Math.ceil(totalCount / limit);
   const hasNextPage = page < totalPages;
   const hasPreviousPage = page > 1;
 
   let offset = (page - 1) * limit;
-  let data = db.select().from(advocates);
   data = data.offset(offset).limit(limit);
 
   const resp = await data.execute();

--- a/src/app/components/button.tsx
+++ b/src/app/components/button.tsx
@@ -1,0 +1,12 @@
+interface IButtonProps {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export default function Button({ children, onClick, disabled }: IButtonProps) {
+  const buttonStyle = "text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2"
+  return (
+    <button onClick={onClick} className={buttonStyle} disabled={disabled}>{children}</button>
+  );
+}

--- a/src/app/components/pagination.tsx
+++ b/src/app/components/pagination.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-interface PaginationProps {
+import Button from "./button";
+
+interface IPaginationProps {
   page: number;
   setNext: () => void;
   setPrevious: () => void;
@@ -20,8 +22,7 @@ export default function Pagination ({
   totalPages,
   hasNextPage,
   hasPreviousPage,
-}: PaginationProps) {
-  const buttonStyle = "text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2"
+}: IPaginationProps) {
   return (
   <div className="mt-4">
     <span className="mr-2">Per Page</span>
@@ -31,9 +32,9 @@ export default function Pagination ({
       <option value="50">50</option>
       <option value="100">100</option>
     </select>
-    <button onClick={setPrevious} disabled={!hasPreviousPage} className={buttonStyle}>{"<<"}</button>
+    <Button onClick={setPrevious} disabled={!hasPreviousPage}>{"<<"}</Button>
     <span className="mr-2 ml-2">{page} of {totalPages}</span>
-    <button onClick={setNext} disabled={!hasNextPage} className={buttonStyle}>{">>"}</button>
+    <Button onClick={setNext} disabled={!hasNextPage}>{">>"}</Button>
   </div>
 );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,6 @@ export default function Home() {
   const searchParams = useSearchParams();
 
   const [advocates, setAdvocates] = useState<IAdvocate[]>([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState<IAdvocate[]>([]);
 
 
   // Get initial values from URL params or defaults

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Pagination from "./components/pagination";
 import { IAdvocate, IAdvocatesResponse } from "@/types";
+import Button from "./components/button";
 
 export default function Home() {
   const router = useRouter();
@@ -14,13 +15,16 @@ export default function Home() {
 
 
   // Get initial values from URL params or defaults
-  const page = parseInt(searchParams.get("page") || "1");
-  const limit = parseInt(searchParams.get("limit") || "10");
+  const page: number = parseInt(searchParams.get("page") || "1");
+  const limit:number = parseInt(searchParams.get("limit") || "10");
+  const search: string = searchParams.get("search") || "";
 
-  const [totalPages, setTotalPages] = useState(0);
-  const [totalCount, setTotalCount] = useState(0);
-  const [hasNextPage, setHasNextPage] = useState(false);
-  const [hasPreviousPage, setHasPreviousPage] = useState(false);
+  const [totalPages, setTotalPages] = useState<number>(0);
+  const [totalCount, setTotalCount] = useState<number>(0);
+  const [hasNextPage, setHasNextPage] = useState<boolean>(false);
+  const [hasPreviousPage, setHasPreviousPage] = useState<boolean>(false);
+  const [timer, setTimer] = useState<NodeJS.Timeout | null>(null);
+  const [searchTerm, setSearchTerm] = useState<string>(search);
 
   // Update URL parameters
   const updateURL = (newParams: Record<string, string | number>) => {
@@ -34,16 +38,21 @@ export default function Home() {
       }
     });
 
+    if (newParams.search !== undefined) {
+      params.set("page", "1");
+    }
+
     router.push(`/?${params.toString()}`, { scroll: false });
   };
   useEffect(() => {
     fetchAdvocates();
-  }, [page, limit]);
+  }, [page, limit, search]);
   
   const fetchAdvocates = () => {
     const urlParams = new URLSearchParams({
       page: page.toString(),
       limit: limit.toString(),
+      search: searchTerm,
     });
 
     fetch(`/api/advocates?${urlParams.toString()}`).then((response: Response) => {
@@ -65,29 +74,29 @@ export default function Home() {
     updateURL({ limit: newLimit });
   };
 
-  const onChange = (e) => {
-    const searchTerm = e.target.value;
-
-    document.getElementById("search-term").innerHTML = searchTerm;
-
-    console.log("filtering advocates...");
-    const filteredAdvocates = advocates.filter((advocate) => {
-      return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
-      );
-    });
-
-    setFilteredAdvocates(filteredAdvocates);
+  const searchAdvoctes = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const q = e.target.value;
+    setSearchTerm(q);
+    if (q === "") {
+      clearSearch();
+    } else {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      setTimer(setTimeout(() => {
+        updateURL({ search: q });
+        setTimer(null);
+      }, 1500));
+    }
   };
 
-  const onClick = () => {
-    console.log(advocates);
-    setFilteredAdvocates(advocates);
+  const clearSearch = () => {
+    if (timer) {
+      clearTimeout(timer);
+      setTimer(null);
+    }
+    setSearchTerm("");
+    updateURL({ search: "" });
   };
 
   return (
@@ -96,12 +105,23 @@ export default function Home() {
       <br />
       <br />
       <div>
-        <p>Search</p>
         <p>
-          Searching for: <span id="search-term"></span>
+          {
+            searchTerm && !timer ?
+              <span>Searching for: {searchTerm} | ({totalCount} results)</span>
+            :
+            <span>Search</span>
+          }
         </p>
-        <input style={{ border: "1px solid black" }} onChange={onChange} />
-        <button onClick={onClick}>Reset Search</button>
+        <input style={{ border: "1px solid black" }} onChange={searchAdvoctes} value={searchTerm} />
+        {timer ? 
+          <>
+            <Button onClick={() => clearTimeout(timer)}>Cancel</Button>
+            <span>Searching...</span>
+          </>
+        : 
+          <Button onClick={clearSearch}>Reset</Button>
+        }
         <Pagination 
           setNext={() => setPage(page + 1)} 
           setPrevious={() => setPage(page - 1)} 


### PR DESCRIPTION
Makes search functionality backend-oriented.

**Why?**
Originally this functionality was accomplished through filtering all of the advocates on the frontend. The introduction of pagination broke this as it would only be filtering a single page, potentially missing a lot of matches otherwise in the database. With this change, we make the search term a filter on the query string that now gets passed to the backend to be a part of the database query, the results of which are paginated.

**Specifics**
This is using `ilike` on searchable fields (first_name, last_name, city, degree, specialties) in Postgres. This is not ideal in terms of performance nor results, but it is somewhat functional. Where it falls short is if you want to search for something like "houston pediatrics". In this case, no results will be returned, whereas a search for either term individually would work. (We'll address this shortcoming in a future PR.) 

For the UX, I maintained a version of the original functionality by making search trigger based on content changes to the input. In this case, though, we wait for 1.5 seconds (tunable) after typing has stopped to fire off the API request. This reduces the number of API requests from the client with partial search terms. To indicate that something is happening during the delay, I added a "Searching..." indicator. This could be swapped out for animations, etc.

**Recommendation**
This should be moved to a more search-specific solution like Elasticsearch. It will be provide better response times and more intuitive response content.