### PR TITLE
UUID pt. 1

### DIFF
--- a/drizzle/0000_boring_harrier.sql
+++ b/drizzle/0000_boring_harrier.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "advocates" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"city" text NOT NULL,
+	"degree" text NOT NULL,
+	"payload" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"years_of_experience" integer NOT NULL,
+	"phone_number" bigint NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);

--- a/drizzle/0001_quick_ser_duncan.sql
+++ b/drizzle/0001_quick_ser_duncan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "advocates" ADD COLUMN "uuid" uuid DEFAULT gen_random_uuid() NOT NULL;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,88 @@
+{
+  "id": "34b2b93b-d6f3-40a4-9972-cbb03442b77a",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.advocates": {
+      "name": "advocates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,95 @@
+{
+  "id": "4f979318-1a56-4e53-b51a-56c2d3dad14c",
+  "prevId": "34b2b93b-d6f3-40a4-9972-cbb03442b77a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.advocates": {
+      "name": "advocates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1758216218596,
+      "tag": "0000_boring_harrier",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1758216286268,
+      "tag": "0001_quick_ser_duncan",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -7,10 +7,12 @@ import {
   serial,
   timestamp,
   bigint,
+  uuid,
 } from "drizzle-orm/pg-core";
 
 const advocates = pgTable("advocates", {
   id: serial("id").primaryKey(),
+  uuid: uuid("uuid").defaultRandom().notNull(),
   firstName: text("first_name").notNull(),
   lastName: text("last_name").notNull(),
   city: text("city").notNull(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface IAdvocate {
-  id: string;
+  id: number;
+  uuid: string;
   firstName: string;
   lastName: string;
   city: string;


### PR DESCRIPTION
Adds `uuid` column to `advocates` table. This is the first step toward migrating away from serial IDs.

**Why?**
Serial IDs increase risk of data exposure. Example: If I can see that an API is exposing data by a serial ID, I can increment or decrement the ID on the request to [potentially] get to data that was not intended for me. So we can make the move to use something random and unique like UUID. 